### PR TITLE
add Testes unitário - Roteiro 14

### DIFF
--- a/src/controller/ControllerHistorico.js
+++ b/src/controller/ControllerHistorico.js
@@ -1,0 +1,59 @@
+class ControllerHistorico {
+    constructor() {
+      // Banco de dados simulado de histórico de vídeos
+      this.historico = {
+        1: [ // id_usuario = 1
+          { id_video: 1, nome: "Introdução à Programação" },
+          { id_video: 2, nome: "JavaScript para Iniciantes" },
+          { id_video: 3, nome: "Aprendendo React" },
+          { id_video: 4, nome: "Desenvolvimento Web" },
+          { id_video: 5, nome: "Técnicas Avançadas de Programação" },
+        ],
+      };
+    }
+  
+    /**
+     * Método consultarHistorico
+     * @param {number} id_usuario - ID do usuário para consultar o histórico.
+     * @returns {Array} - Lista de vídeos assistidos pelo usuário.
+     */
+    consultarHistorico(id_usuario) {
+      return this.historico[id_usuario] || [];
+    }
+  
+    /**
+     * Método removerVideo
+     * @param {number} id_usuario - ID do usuário.
+     * @param {number} id_video - ID do vídeo a ser removido.
+     * @returns {string} - Mensagem de confirmação ou erro.
+     */
+    removerVideo(id_usuario, id_video) {
+      if (!this.historico[id_usuario]) return "Usuário não encontrado.";
+  
+      const videoIndex = this.historico[id_usuario].findIndex(
+        (video) => video.id_video === id_video
+      );
+  
+      if (videoIndex === -1) {
+        return "Vídeo não encontrado no histórico.";
+      }
+  
+      this.historico[id_usuario].splice(videoIndex, 1);
+      return "Vídeo removido com sucesso.";
+    }
+  
+    /**
+     * Método limparVideosHistorico
+     * @param {number} id_usuario - ID do usuário.
+     * @returns {string} - Mensagem de confirmação de limpeza.
+     */
+    limparVideosHistorico(id_usuario) {
+      if (!this.historico[id_usuario]) return "Usuário não encontrado.";
+       
+      this.historico[id_usuario] = [];
+      return "Histórico de vídeos limpo com sucesso.";
+    }
+  }
+  
+  export default ControllerHistorico;
+  

--- a/src/tests/unit/ana/testeRt014.test.js
+++ b/src/tests/unit/ana/testeRt014.test.js
@@ -1,0 +1,49 @@
+import { describe, it, beforeEach, expect } from "vitest";
+import ControllerHistorico from "src/controller/ControllerHistorico"; 
+
+describe("RT014: Histórico de vídeos assistidos - Testes do método de histórico de vídeos", () => {
+  let controllerHistorico;
+
+  beforeEach(() => {
+    controllerHistorico = new ControllerHistorico();
+  });
+
+  // CT025: Exibir o histórico de vídeos assistidos
+  it("CT025: Deve exibir o histórico de vídeos do usuário", () => {
+    const id_usuario = 1;
+    const resultado = controllerHistorico.consultarHistorico(id_usuario);
+    expect(resultado).toEqual([
+      { id_video: 1, nome: "Introdução à Programação" },
+      { id_video: 2, nome: "JavaScript para Iniciantes" },
+      { id_video: 3, nome: "Aprendendo React" },
+      { id_video: 4, nome: "Desenvolvimento Web" },
+      { id_video: 5, nome: "Técnicas Avançadas de Programação" },
+    ]);
+  });
+
+  // CT026: Permitir remover um vídeo específico do histórico
+  it("CT026: Deve remover um vídeo específico do histórico", () => {
+    const id_usuario = 1;
+    const id_video = 5;
+    const resultado = controllerHistorico.removerVideo(id_usuario, id_video);
+    expect(resultado).toBe("Vídeo removido com sucesso.");
+
+    const historicoAtualizado = controllerHistorico.consultarHistorico(id_usuario);
+    expect(historicoAtualizado).toEqual([
+      { id_video: 1, nome: "Introdução à Programação" },
+      { id_video: 2, nome: "JavaScript para Iniciantes" },
+      { id_video: 3, nome: "Aprendendo React" },
+      { id_video: 4, nome: "Desenvolvimento Web" },
+    ]);
+  });
+
+  // CT027: Permitir limpar o histórico de vídeos
+  it("CT027: Deve limpar todo o histórico de vídeos do usuário", () => {
+    const id_usuario = 1;
+    const resultado = controllerHistorico.limparVideosHistorico(id_usuario);
+    expect(resultado).toBe("Histórico de vídeos limpo com sucesso.");
+
+    const historicoVazio = controllerHistorico.consultarHistorico(id_usuario);
+    expect(historicoVazio).toEqual([]);
+  });
+});


### PR DESCRIPTION
Verificar erros na funcionalidade de manutenção do histórico de vídeos, incluindo exibição, limpeza completa do histórico e remoção individual de vídeos.

Adicionando ControllerHistorico + classe do roteiro de teste 14 para os métodos consultarHistorico, removerVideo e limparVideosHistorico